### PR TITLE
Task 039 - JUnit Tests set up - Order service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,16 +105,30 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.sonarsource.scanner.maven</groupId>
+				<artifactId>sonar-maven-plugin</artifactId>
+				<version>3.11.0.3922</version>
+			</plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.10</version>
-				<configuration>
-					<excludes>
-						<exclude>**/dto/**</exclude>
-						<exclude>**/entity/**</exclude>
-						<exclude>**/SequenceGenerator.class/**</exclude>
-					</excludes>
-				</configuration>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,18 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.10</version>
+				<configuration>
+					<excludes>
+						<exclude>**/dto/**</exclude>
+						<exclude>**/entity/**</exclude>
+						<exclude>**/SequenceGenerator.class/**</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/com/project/tejas/order_service/FoodOrderServiceApplicationTests.java
+++ b/src/test/java/com/project/tejas/order_service/FoodOrderServiceApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class FoodOrderServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
 }

--- a/src/test/java/com/project/tejas/order_service/controller/OrderServiceControllerTest.java
+++ b/src/test/java/com/project/tejas/order_service/controller/OrderServiceControllerTest.java
@@ -1,0 +1,52 @@
+package com.project.tejas.order_service.controller;
+
+import com.project.tejas.order_service.dto.*;
+import com.project.tejas.order_service.service.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class OrderServiceControllerTest {
+
+    @Mock
+    OrderService orderService;
+
+    @InjectMocks
+    OrderServiceController orderServiceController;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testSaveFoodOrder(){
+        List<MenuItemDTO> mockMenuItemList = Arrays.asList(
+                new MenuItemDTO(1, "dish 1", "Desc 1", true, 123L, 10, 1),
+                new MenuItemDTO(2, "dish 2", "desc 2", false, 234L, 20, 2)
+        );
+        Integer mockUserId = 1;
+        RestaurantListingDTO mockRestaurant = new RestaurantListingDTO(1, "Restaurant 1", "Address 1", "city 1", "desc 1");
+        UserDetailsDTO mockUserDTO = new UserDetailsDTO(1, "username1", "password1", "Address 1", "city 1");
+        FoodOrderDetailsFEClientDTO mockFEclientDTO = new FoodOrderDetailsFEClientDTO(mockMenuItemList, mockUserId, mockRestaurant);
+        FoodOrderDTO mockFoodOrder = new FoodOrderDTO(1, mockMenuItemList, mockRestaurant, mockUserDTO);
+        when(orderService.saveFoodOrderInDb(mockFEclientDTO)).thenReturn(mockFoodOrder);
+
+        ResponseEntity<FoodOrderDTO> response = orderServiceController.saveFoodOrder(mockFEclientDTO);
+
+        assertEquals(mockFoodOrder, response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(orderService, times(1)).saveFoodOrderInDb(mockFEclientDTO);
+    }
+
+}

--- a/src/test/java/com/project/tejas/order_service/service/OrderServiceTest.java
+++ b/src/test/java/com/project/tejas/order_service/service/OrderServiceTest.java
@@ -55,6 +55,7 @@ public class OrderServiceTest {
         FoodOrderDTO resulyDTO = orderService.saveFoodOrderInDb(mockFEClientDTO);
 
         assertEquals(FoodOrderMapper.INSTANCE.mapFoodOrdertoFoodOrderDTO(mockFoodOrder), resulyDTO);
+        verify(sequenceGenerator, times(1)).generateNextOrderId();
         verify(orderRepo, times(1)).save(mockFoodOrder);
     }
 

--- a/src/test/java/com/project/tejas/order_service/service/OrderServiceTest.java
+++ b/src/test/java/com/project/tejas/order_service/service/OrderServiceTest.java
@@ -1,0 +1,61 @@
+package com.project.tejas.order_service.service;
+
+import com.project.tejas.order_service.dto.*;
+import com.project.tejas.order_service.entity.FoodOrder;
+import com.project.tejas.order_service.mapper.FoodOrderMapper;
+import com.project.tejas.order_service.repo.OrderRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class OrderServiceTest {
+
+    @Mock
+    OrderRepo orderRepo;
+
+    @Mock
+    SequenceGenerator sequenceGenerator;
+
+    @Mock
+    RestTemplate restTemplate;
+
+    @InjectMocks
+    OrderService orderService;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testSaveFoodOrderInDb(){
+        Integer mockOrderId = 123;
+        List<MenuItemDTO> mockMenuList = Arrays.asList(
+                new MenuItemDTO(1, "dish 1", "desc 1", true, 123L, 10, 1),
+                new MenuItemDTO(2, "dish 2", "desc 2", false, 234L, 20, 2)
+        );
+        RestaurantListingDTO mockRestaurant = new RestaurantListingDTO(1, "Restaurant 1", "address 1", "city 1", "desc 1");
+        UserDetailsDTO mockUserDTO = new UserDetailsDTO(1, "username1", "password1", "address1", "city1");
+        FoodOrder mockFoodOrder = new FoodOrder(mockOrderId,mockMenuList, mockRestaurant, mockUserDTO);
+        FoodOrderDetailsFEClientDTO mockFEClientDTO = new FoodOrderDetailsFEClientDTO(mockMenuList, 1, mockRestaurant);
+        when(sequenceGenerator.generateNextOrderId()).thenReturn(mockOrderId);
+        when(restTemplate.getForObject(anyString(), eq(UserDetailsDTO.class))).thenReturn(mockUserDTO);
+        when(orderRepo.save(mockFoodOrder)).thenReturn(mockFoodOrder);
+
+        FoodOrderDTO resulyDTO = orderService.saveFoodOrderInDb(mockFEClientDTO);
+
+        assertEquals(FoodOrderMapper.INSTANCE.mapFoodOrdertoFoodOrderDTO(mockFoodOrder), resulyDTO);
+        verify(orderRepo, times(1)).save(mockFoodOrder);
+    }
+
+}


### PR DESCRIPTION
Task 039 - JUnit Tests set up - Order service

Description: Set up Test files with their JUnit test cases for Controller and Service classes. Also added exclusions for DTO and Entity in the pom files as they are boiler plate code, and hence should not be counted for test coverage. Achieved 80% coverage with this.

Files changed:
OrderServiceControllerTest.java (created)
OrderServiceTest.java (created)
OrderServiceApplicationTest.java
pom.xml